### PR TITLE
_maxStickAngle adjusted to 28 degrees, same default calibration values for both sticks

### DIFF
--- a/PhobGCC/PhobGCC.ino
+++ b/PhobGCC/PhobGCC.ino
@@ -191,7 +191,7 @@ const int _noOfAdjNotches = 12;
 float _ADCScale = 1;
 float _ADCScaleFactor = 1;
 const int _notCalibrating = -1;
-const float _maxStickAngle = 0.67195176201;//38.5 degrees; this is the max angular deflection of the stick.
+const float _maxStickAngle = 0.4886921906;//28 degrees; this is the max angular deflection of the stick.
 bool	_calAStick = true; //determines which stick is being calibrated (if false then calibrate the c-stick)
 bool _advanceCal = false;
 bool _advanceCalPressed = false;
@@ -206,10 +206,9 @@ float _notchPointsX[_noOfNotches+1]; //array to hold the x coordinates of the no
 float _notchPointsY[_noOfNotches+1]; //array to hold the x coordinates of the notches for calibration
 //                                                         right                     notch 1                   up right                  notch 2                   up                        notch 3                   up left                   notch 4                   left                      notch 5                   down left                 notch 6                   down                      notch 7                   down right                notch 8
 //                                                         0            1            2            3            4            5            6            7            8            9            10           11           12           13           14           15           16           17           18           19           20           21           22           23           24           25           26           27           28           29           30           31
-const float _cDefaultCalPointsX[_noOfCalibrationPoints] = {0.507073712, 0.9026247224,0.5072693007,0.5001294236,0.5037118952,0.8146074226,0.5046028951,0.5066508636,0.5005339326,0.5065670067,0.5006805723,0.5056853599,0.5058308703,0.1989667596,0.5009560613,0.508400395, 0.507729394, 0.1003568119,0.5097473849,0.5074989796,0.5072406293,0.2014042034,0.5014653263,0.501119675, 0.502959011, 0.5032433665,0.5018446562,0.5085523857,0.5099732513,0.8100862401,0.5089320995,0.5052066109};
-const float _cDefaultCalPointsY[_noOfCalibrationPoints] = {0.5006151799,0.5025356503,0.501470528, 0.5066983468,0.5008275958,0.8094667357,0.5008874968,0.5079207909,0.5071239815,0.9046004275,0.5010136589,0.5071086316,0.5058914031,0.8076523013,0.5078213507,0.5049117887,0.5075638281,0.5003774649,0.504562192, 0.50644895,  0.5074859854,0.1983865682,0.5074515232,0.5084323402,0.5015846608,0.1025902875,0.5043605453,0.5070589342,0.5073953693,0.2033337702,0.5005351734,0.5056548782};
-const float _aDefaultCalPointsX[_noOfCalibrationPoints] = {0.3010610568,0.3603937084,0.3010903951,0.3000194135,0.3005567843,0.3471911134,0.3006904343,0.3009976295,0.3000800899,0.300985051, 0.3001020858,0.300852804, 0.3008746305,0.2548450139,0.3001434092,0.3012600593,0.3011594091,0.2400535218,0.3014621077,0.3011248469,0.3010860944,0.2552106305,0.3002197989,0.3001679513,0.3004438517,0.300486505, 0.3002766984,0.3012828579,0.3014959877,0.346512936, 0.3013398149,0.3007809916};
-const float _aDefaultCalPointsY[_noOfCalibrationPoints] = {0.300092277, 0.3003803475,0.3002205792,0.301004752, 0.3001241394,0.3464200104,0.3001331245,0.3011881186,0.3010685972,0.3606900641,0.3001520488,0.3010662947,0.3008837105,0.3461478452,0.3011732026,0.3007367683,0.3011345742,0.3000566197,0.3006843288,0.3009673425,0.3011228978,0.2547579852,0.3011177285,0.301264851, 0.3002376991,0.2403885431,0.3006540818,0.3010588401,0.3011093054,0.2555000655,0.300080276, 0.3008482317};
+
+const float _defaultCalPointsX[_noOfCalibrationPoints] = {0.3010610568,0.3603937084,0.3010903951,0.3000194135,0.3005567843,0.3471911134,0.3006904343,0.3009976295,0.3000800899,0.300985051, 0.3001020858,0.300852804, 0.3008746305,0.2548450139,0.3001434092,0.3012600593,0.3011594091,0.2400535218,0.3014621077,0.3011248469,0.3010860944,0.2552106305,0.3002197989,0.3001679513,0.3004438517,0.300486505, 0.3002766984,0.3012828579,0.3014959877,0.346512936, 0.3013398149,0.3007809916};
+const float _defaultCalPointsY[_noOfCalibrationPoints] = {0.300092277, 0.3003803475,0.3002205792,0.301004752, 0.3001241394,0.3464200104,0.3001331245,0.3011881186,0.3010685972,0.3606900641,0.3001520488,0.3010662947,0.3008837105,0.3461478452,0.3011732026,0.3007367683,0.3011345742,0.3000566197,0.3006843288,0.3009673425,0.3011228978,0.2547579852,0.3011177285,0.301264851, 0.3002376991,0.2403885431,0.3006540818,0.3010588401,0.3011093054,0.2555000655,0.300080276, 0.3008482317};
 //                                                         right        up          left          down         up right     up left      down left    down right   notch 1      notch 2      notch 3      notch 4      notch 5      notch 6      notch 7      notch 8
 const int _calOrder[_noOfCalibrationPoints] =             {0, 1,        8, 9,       16, 17,       24, 25,      4, 5,        12, 13,      20, 21,      28, 29,      2, 3,        6, 7,        10, 11,      14, 15,      18, 19,      22, 23,      26, 27,      30, 31};
 //                                                         right        notch 1      up right     notch 2      up           notch 3      up left      notch 4      left         notch 5      down left    notch 6      down         notch 7      down right   notch 8
@@ -1125,8 +1124,8 @@ void resetDefaults(){
 	EEPROM.put(_eepromCNotchAngles,_cNotchAngles);
 
 	for(int i = 0; i < _noOfCalibrationPoints; i++){
-		_tempCalPointsX[i] = _aDefaultCalPointsX[i];
-		_tempCalPointsY[i] = _aDefaultCalPointsY[i];
+		_tempCalPointsX[i] = _defaultCalPointsX[i];
+		_tempCalPointsY[i] = _defaultCalPointsY[i];
 	}
 	EEPROM.put(_eepromAPointsX,_tempCalPointsX);
 	EEPROM.put(_eepromAPointsY,_tempCalPointsY);
@@ -1139,8 +1138,8 @@ void resetDefaults(){
 	notchCalibrate(_cleanedPointsX, _cleanedPointsY, _notchPointsX, _notchPointsY, _noOfNotches, _aAffineCoeffs, _aBoundaryAngles);
 
 	for(int i = 0; i < _noOfCalibrationPoints; i++){
-		_tempCalPointsX[i] = _cDefaultCalPointsX[i];
-		_tempCalPointsY[i] = _cDefaultCalPointsY[i];
+		_tempCalPointsX[i] = _defaultCalPointsX[i];
+		_tempCalPointsY[i] = _defaultCalPointsY[i];
 	}
 	EEPROM.put(_eepromCPointsX,_tempCalPointsX);
 	EEPROM.put(_eepromCPointsY,_tempCalPointsY);


### PR DESCRIPTION
Changing the max stick angle has a small impact on the diagonal gate coordinates, will ideally be ~74,74 instead of ~76,76. Using the same default calibration values for both sticks makes sense now that we are recommending hall effect sensors for both. The defaults will still be bad, but not as bad as they were for the c-stick.