### PR TITLE
Increased the fast baudrate for t4.0 from 2.5MHz to 2.6MHz to allow f…

### DIFF
--- a/PhobGCC/PhobGCC.ino
+++ b/PhobGCC/PhobGCC.ino
@@ -356,7 +356,7 @@ int _bitQueue = 8;
 int _waitQueue = 0;
 int _writeQueue = 0;
 uint8_t _cmdByte = 0;
-const int _fastBaud = 2500000;
+const int _fastBaud = 2600000;
 const int _slowBaud = 2000000;
 const int _probeLength = 24;
 const int _originLength = 80;
@@ -757,7 +757,7 @@ void commInt() {
 			//write the stop bit
 			Serial2.write(0b11111100);
 			//start the timer to reset the the serial port when the response has been sent
-			timer1.trigger(175);
+			timer1.trigger(165);
 
 
 		}


### PR DESCRIPTION
…or 2kHz polling in smashscope, decreased the serial reset timer to match