### PR TITLE
Make rumble brake be set by analog

### DIFF
--- a/PhobGCC/PhobGCC.ino
+++ b/PhobGCC/PhobGCC.ino
@@ -718,16 +718,16 @@ void commInt() {
 			}
 #ifdef RUMBLE
 			if(_cmdByte & 0b00000001 && _rumble > 0){
-				digitalWriteFast(_pinBrake,LOW);
+				analogWrite(_pinBrake,0);
 				analogWrite(_pinRumble, _rumblePower);
 			}
 			else if(_cmdByte & 0b00000010){
 				analogWrite(_pinRumble,0);
-				digitalWriteFast(_pinBrake,HIGH);
+				analogWrite(_pinBrake,256);
 			}
 			else{
 				analogWrite(_pinRumble,0);
-				digitalWriteFast(_pinBrake,LOW);
+				analogWrite(_pinBrake,0);
 			}
 #endif
 			if(_reportCount == 0){


### PR DESCRIPTION
Before when it was set by digitalWriteFast it was happening before the
analogWrite for turning off rumble, causing overlap.

This caused disconnections during rumble on a troublesome Gamecube.

It may fix issues reported on Smash Ultimate too.