### PR TITLE
[DRAFT] Update digital-only trigger mode with proof of concept impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ fp-info-cache
 *.vimrc
 # cmake build stuff
 *build*/
+# vscode
+.vscode

--- a/PhobGCC/common/phobGCC.h
+++ b/PhobGCC/common/phobGCC.h
@@ -1654,7 +1654,7 @@ void processButtons(Pins &pin, Buttons &btn, Buttons &hardware, ControlConfig &c
 			tempBtn.La = (uint8_t) readLa(pin, controls.lTrigInitial, 1) * shutoffLa;
 			break;
 		case 1: //Digital Only Trigger state
-			tempBtn.La = (uint8_t) 0;
+			tempBtn.L = (uint8_t) readLa(pin, controls.lTrigInitial, 1) * shutoffLa > 10 ? 1 : 0;
 			break;
 		case 2: //Analog Only Trigger state
 			tempBtn.L  = (uint8_t) 0;
@@ -1694,7 +1694,7 @@ void processButtons(Pins &pin, Buttons &btn, Buttons &hardware, ControlConfig &c
 			tempBtn.Ra = (uint8_t) readRa(pin, controls.rTrigInitial, 1) * shutoffRa;
 			break;
 		case 1: //Digital Only Trigger state
-			tempBtn.Ra = (uint8_t) 0;
+			tempBtn.R = (uint8_t) readRa(pin, controls.rTrigInitial, 1) * shutoffRa > 10 ? 1 : 0;
 			break;
 		case 2: //Analog Only Trigger state
 			tempBtn.R  = (uint8_t) 0;


### PR DESCRIPTION
In the current implementation of digital only trigger mode, analog trigger inputs are disabled entirely, while digital trigger inputs are preserved.  I want a new trigger mode called "exclusive digital" or something of the sort which results in a digital trigger input when _any_ analog value above some low threshold is read.

I want this because
* I want to powershield falco lasers more consistently.
* I want to avoid ADT.
* I can't use the current implementation of digital only because I shield drop by only pushing the trigger in half way, and I shield drop and power shield with the same trigger.

I flashed the contents of this branch onto my phob and I get the desired behavior: when I change my trigger mode to 2, I can slightly hold down the trigger and I get a digital full shield every time.  Here's a visual demonstration of the behavior as seen through smashscope (the mode is enabled for the right trigger, while the left trigger is still in the default mode): 

![digital_trigger](https://github.com/PhobGCC/PhobGCC-SW/assets/9982381/6b9bd24d-58bd-4bba-a0e2-8030ae8692eb)

As the title suggests this is still in a draft state, and to be considered complete I think the following changes should be made
1. Create a new trigger mode, as opposed to replacing the existing "digital only" mode.
2. Allow the threshold (currently hardcoded to 10) to be configurable, similar to some of the other modes.
Is this a feature that would get merged?  Does anyone have concerns/comments with the above proposal?