### PR TITLE
add github actions workflow for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,110 @@
+name: Test Teensy and RP2040 Builds
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-teensies:
+    runs-on: ubuntu-latest
+
+    # The Teensy 3.2 uses the 3.1 FQBN
+    strategy:
+      matrix:
+        fqbn:
+          - teensy:avr:teensy31
+          - teensy:avr:teensy40
+        phob_version:
+          - 1_0
+          - 1_1
+          - 1_2
+        diode_short:
+          - true
+          - false
+        exclude:
+          - fqbn: teensy:avr:teensy31
+            phob_version: 1_2
+          - fqbn: teensy:avr:teensy40
+            phob_version: 1_0
+          - phob_version: 1_2
+            diode_short: true
+
+    env:
+      H_FILE: ${{ format('{0}Teensy{1}{2}.h', matrix.phob_version, matrix.fqbn == 'teensy:avr:teensy31' && '3_2' || '4_0', matrix.diode_short == true && 'DiodeShort' || '') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: uncomment include
+        run: sed -i "/$H_FILE/s://::" PhobGCC/common/phobGCC.h
+        
+      - uses: arduino/compile-sketches@v1.1.0
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          platforms: |
+            - name: "teensy:avr"
+              source-url: "https://www.pjrc.com/teensy/package_teensy_index.json"
+          libraries: |
+            - name: CurveFitting
+            - name: Bolder Flight Systems Eigen
+            - name: Bounce2
+            - name: TeensyTimerTool
+              version: 1.0.0
+          sketch-paths: |
+            - PhobGCC
+          verbose: true
+
+
+  build-rp2040:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: apt update
+      run: sudo apt update
+
+    # # DOES NOT WORK
+    # # Get/cache requisite APT packages
+    # - uses: awalsh128/cache-apt-pkgs-action@v1.3.0
+    #   with:
+    #     packages: cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+
+    - name: apt install
+      run: sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
+
+    - uses: actions/checkout@v4
+      with:
+        path: PhobGCC-SW
+
+    - name: uncomment include
+      run: sed -i '/Phob2_0.h/s://::' PhobGCC-SW/PhobGCC/common/phobGCC.h
+
+    # Cache action for the pico-sdk directory
+    # If the cache doesn't already exist it will be created at the end of the workflow
+    - name: cache pico sdk
+      id: cache-pico-sdk
+      uses: actions/cache@v3
+      with:
+        path: pico-sdk
+        key: rp2040-pico-sdk
+
+    - name: clone pico-sdk
+      if: steps.cache-pico-sdk.outputs.cache-hit != 'true'
+      uses: actions/checkout@v4
+      with:
+        repository: raspberrypi/pico-sdk
+        path: pico-sdk
+
+    - name: init pico-sdk submodules
+      if: steps.cache-pico-sdk.outputs.cache-hit != 'true'
+      run: cd $GITHUB_WORKSPACE/pico-sdk && git submodule update --init
+
+    - name: set pico sdk path
+      run: echo "PICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk" >> "$GITHUB_ENV"
+
+    - name: cmake
+      run: cd PhobGCC-SW/PhobGCC/rp2040 && mkdir build && cd build && cmake ..
+      
+    - name: make
+      run: cd PhobGCC-SW/PhobGCC/rp2040/build && make


### PR DESCRIPTION
This GitHub Actions workflow will build the source for each of the `#include` options in `common/phobGCC.h`. The purpose would be to verify that code changes build successfully on all the available boards. As it stands, this workflow does not save build artifacts like `.hex` or `.uf2` files. But such a feature could be added by leveraging GitHub Packages.

As it's currently designed, the workflow would be triggered by pushes or PRs to the `main` branch. Merging wouldn't be contingent on successful builds; that would have to be configured in the repo settings. If it's running too frequently or not when you want, the triggers can be modified as needed.

I understand that this probably isn't all that useful for PhobGCC since build failures on specific board configs are rare or nonexistent. It was mainly a personal project for me to dabble in GitHub Actions. Feel free to take it or leave it :)

Here's an example of how the workflow looks when it's done:
![image](https://github.com/PhobGCC/PhobGCC-SW/assets/5024564/c6561e7e-4ea7-423e-9400-9935ce5533f1)

_Side Note:_ I skipped the PicoProtoboard.h build, but it can easily be included if wanted.