### PR TITLE
add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ fp-info-cache
 *.vimrc
 # cmake build stuff
 *build*/
+/.direnv
+/result
+/.vscode

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1708702655,
+        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c5101e457206dd437330d283d6626944e28794b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: (flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      pico-sdk = pkgs.fetchFromGitHub {
+        owner = "raspberrypi";
+        repo = "pico-sdk";
+        rev = "1.5.1";
+        hash = "sha256-GY5jjJzaENL3ftuU5KpEZAmEZgyFRtLwGVg3W1e/4Ho=";
+        fetchSubmodules = true;
+      };
+    in
+    {
+      devShells.default = pkgs.mkShell {
+        nativeBuildInputs = builtins.attrValues {
+          inherit (pkgs) cmake gcc-arm-embedded python311;
+        };
+
+        CMAKE_PATH = "${pkgs.cmake}/bin/cmake";
+        PICO_SDK_PATH = "${pico-sdk}";
+      };
+
+      packages.default = self.packages.${system}.rp2040;
+
+      packages.rp2040 =
+        let
+          version = "0.29.1";
+        in
+        pkgs.stdenv.mkDerivation
+          {
+            name = "phobgcc-rp2040";
+            inherit version;
+
+            src = self;
+
+            postUnpack = ''
+              export sourceRoot=$sourceRoot/PhobGCC/rp2040
+            '';
+
+            nativeBuildInputs = builtins.attrValues {
+              inherit (pkgs) cmake gcc-arm-embedded python311;
+            };
+
+            cmakeFlags = [
+              "-DCMAKE_C_COMPILER=${pkgs.gcc-arm-embedded}/bin/arm-none-eabi-gcc"
+              "-DCMAKE_CXX_COMPILER=${pkgs.gcc-arm-embedded}/bin/arm-none-eabi-g++"
+            ];
+
+            prePatch = ''
+              sed -i 's|//#include "../rp2040/include/Phob2_0.h"|#include "../rp2040/include/Phob2_0.h"|' ../common/phobGCC.h
+            '';
+
+            PICO_SDK_PATH = "${pico-sdk}";
+
+            installPhase = ''
+              mkdir -p $out/bin
+              cp -r phobgcc_rp2040.uf2 $out/bin/phobgcc_rp2040_${version}.uf2
+            '';
+
+            meta = {
+              description = "Software for a custom Gamecube controller that uses Hall effect magnetic sensors to read the sticks.";
+              homepage = "https://github.com/PhobGCC/PhobGCC-SW";
+            };
+          };
+    }));
+}


### PR DESCRIPTION
Adds a flake for use with the nix build system. This way, one can simply run

```shell
nix build .#
```

in order to build the `rp2040` project. Nix will fetch all necessary development tools (toolchain, `pico-sdk`, etc.) for the user and compile the phob firmware. No other modifications are needed (not even manually uncommenting the required line in `PhobGCC/common/phobGCC.h`).