### PR TITLE
Add other joybus mode support

### DIFF
--- a/PhobGCC/rp2040/include/comms/gcReport.hpp
+++ b/PhobGCC/rp2040/include/comms/gcReport.hpp
@@ -3,18 +3,72 @@
 
 #include "pico/stdlib.h"
 
-struct __attribute__((packed)) GCReport {
-    uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
-    uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
-    uint8_t xStick;
-    uint8_t yStick;
-    uint8_t cxStick;
-    uint8_t cyStick;
-    uint8_t analogL;
-    uint8_t analogR;
-};
+typedef union {
 
-const GCReport defaultGcReport = {
+    struct {
+        uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
+        uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
+        uint8_t xStick;
+        uint8_t yStick;
+        uint8_t cxStick;
+        uint8_t cyStick;
+        uint8_t analogL;
+        uint8_t analogR;
+    }; // mode3 (default reading mode)
+
+    struct {
+        uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
+        uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
+        uint8_t xStick;
+        uint8_t yStick;
+        uint8_t cxStick;
+        uint8_t cyStick;
+        uint8_t analogL : 4;
+        uint8_t analogR : 4;
+        uint8_t analogA : 4;
+        uint8_t analogB : 4;
+    } mode0;
+
+    struct {
+        uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
+        uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
+        uint8_t xStick;
+        uint8_t yStick;
+        uint8_t cxStick : 4;
+        uint8_t cyStick : 4;
+        uint8_t analogL;
+        uint8_t analogR;
+        uint8_t analogA : 4;
+        uint8_t analogB : 4;
+    } mode1;
+
+    struct {
+        uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
+        uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
+        uint8_t xStick;
+        uint8_t yStick;
+        uint8_t cxStick : 4;
+        uint8_t cyStick : 4;
+        uint8_t analogL : 4;
+        uint8_t analogR : 4;
+        uint8_t analogA;
+        uint8_t analogB;
+    } mode2;
+
+    struct {
+        uint8_t a : 1; uint8_t b : 1; uint8_t x:1; uint8_t y : 1; uint8_t start : 1; uint8_t pad0 : 3;
+        uint8_t dLeft : 1; uint8_t dRight : 1; uint8_t dDown : 1; uint8_t dUp : 1; uint8_t z : 1; uint8_t r : 1; uint8_t l : 1; uint8_t pad1 : 1;
+        uint8_t xStick;
+        uint8_t yStick;
+        uint8_t cxStick;
+        uint8_t cyStick;
+        uint8_t analogA;
+        uint8_t analogB;
+    } mode4;
+
+} GCReport;
+
+const GCReport defaultGcReport = {{
     .a=0, .b=0, .x=0, .y=0, .start=0, .pad0=0,
     .dLeft=0, .dRight=0, .dDown=0, .dUp=0, .z=0, .r=0, .l=0, .pad1=1,
     .xStick=127,
@@ -23,6 +77,6 @@ const GCReport defaultGcReport = {
     .cyStick=127,
     .analogL=0,
     .analogR=0
-};
+}};
 
 #endif

--- a/PhobGCC/rp2040/src/joybus.cpp
+++ b/PhobGCC/rp2040/src/joybus.cpp
@@ -5,6 +5,7 @@
 
 #include "hardware/pio.h"
 #include "joybus.pio.h"
+#include <string.h>
 
 #define ORG 127
 
@@ -54,6 +55,49 @@ void __time_critical_func(convertToPio)(const uint8_t* command, const int len, u
     }
     // End bit
     result[len / 2] += 3 << (2 * (8 * (len % 2)));
+}
+
+void __time_critical_func(convertGCReport)(GCReport* report, GCReport* dest_report, uint8_t mode) {
+    memcpy(dest_report, report, 8);
+    if (mode == 1)
+    {
+        dest_report->mode1.cxStick = report->cxStick >> 4;
+        dest_report->mode1.cyStick = report->cyStick >> 4;
+        dest_report->mode1.analogL = report->analogL;
+        dest_report->mode1.analogR = report->analogR;
+        dest_report->mode1.analogA = 0;
+        dest_report->mode1.analogB = 0;
+    }
+    else if (mode == 2)
+    {
+        dest_report->mode2.cxStick = report->cxStick >> 4;
+        dest_report->mode2.cyStick = report->cyStick >> 4;
+        dest_report->mode2.analogL = report->analogL >> 4;
+        dest_report->mode2.analogR = report->analogR >> 4;
+        dest_report->mode2.analogA = 0;
+        dest_report->mode2.analogB = 0;
+    }
+    else if (mode == 4)
+    {
+        dest_report->mode4.cxStick = report->cxStick;
+        dest_report->mode4.cyStick = report->cyStick;
+        dest_report->mode4.analogA = 0;
+        dest_report->mode4.analogB = 0;
+    }
+    else if (mode == 3)
+    {
+        return;
+    }
+    // Mode 0, 5, 6, 7
+    else
+    {
+        dest_report->mode0.cxStick = report->cxStick;
+        dest_report->mode0.cyStick = report->cyStick;
+        dest_report->mode0.analogL = report->analogL >> 4;
+        dest_report->mode0.analogR = report->analogR >> 4;
+        dest_report->mode0.analogA = 0;
+        dest_report->mode0.analogB = 0;
+    }
 }
 
 void __time_critical_func(enterMode)(const int dataPin,
@@ -119,13 +163,16 @@ void __time_critical_func(enterMode)(const int dataPin,
             // It must be very fast (few us max) to be done between poll and response and still be compatible with adapters
             // Consider whether that makes sense for your project. If your state building is long, use a different control flow i.e precompute somehow and have func read it
             GCReport gcReport = func();
+            GCReport dest_report;
 
 			//get the second byte; we do this interleaved with work that must be done
             buffer[0] = pio_sm_get_blocking(pio, 0);
 
+            convertGCReport(&gcReport, &dest_report, buffer[0]);
+
             uint32_t result[5];
             int resultLen;
-            convertToPio((uint8_t*)(&gcReport), 8, result, resultLen);
+            convertToPio((uint8_t*)(&dest_report), 8, result, resultLen);
 
 			//get the third byte; we do this interleaved with work that must be done
             buffer[0] = pio_sm_get_blocking(pio, 0);

--- a/PhobGCC/rp2040/src/main.cpp
+++ b/PhobGCC/rp2040/src/main.cpp
@@ -18,7 +18,7 @@ DataCapture _dataCapture;
 
 //This gets called by the comms library
 GCReport __no_inline_not_in_flash_func(buttonsToGCReport)() {
-	GCReport report = {
+	GCReport report = {{
 		.a       = _btn.A,
 		.b       = _btn.B,
 		.x       = _btn.X,
@@ -39,7 +39,7 @@ GCReport __no_inline_not_in_flash_func(buttonsToGCReport)() {
 		.cyStick = _btn.Cy,
 		.analogL = _btn.La,
 		.analogR = _btn.Ra
-	};
+	}};
 	return report;
 }
 


### PR DESCRIPTION
By @mizuyoukanao

> The current phob firmware only supports joybus protocol read mode 3, but some games like Luigi's Mansion use mode 0.
> The following URL may be helpful.
> <https://github.com/NicoHood/Nintendo/blob/master/src/Gamecube.c#L98>
> <https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/HW/SI/SI_DeviceGCController.cpp#L167>
> I don't have phob hardware so I can't guarantee it works, but I have created a fork of phob firmware that supports the other read modes (0,1,2,4,5,6,7).