### PR TITLE
Brake rumble only when asked to

### DIFF
--- a/PhobGCC/rp2040/src/joybus.cpp
+++ b/PhobGCC/rp2040/src/joybus.cpp
@@ -6,6 +6,7 @@
 #include "hardware/pio.h"
 #include "joybus.pio.h"
 #include <string.h>
+#include <math.h>
 
 #define ORG 127
 
@@ -94,6 +95,8 @@ void __time_critical_func(convertGCReport)(GCReport* report, GCReport* dest_repo
     }
 }
 
+
+
 void __time_critical_func(enterMode)(const int dataPin,
                                      const int rumblePin,
                                      const int brakePin,
@@ -121,10 +124,9 @@ void __time_critical_func(enterMode)(const int dataPin,
     pio_sm_set_enabled(pio, 0, true);
     
     while (true) {
-        uint8_t buffer[3];
-        buffer[0] = pio_sm_get_blocking(pio, 0);
+        uint8_t joybusByte = pio_sm_get_blocking(pio, 0);
 
-        if (buffer[0] == 0) { // Probe
+        if (joybusByte == 0) { // Probe
             uint8_t probeResponse[3] = { 0x09, 0x00, 0x03 };
             uint32_t result[2];
             int resultLen;
@@ -137,7 +139,7 @@ void __time_critical_func(enterMode)(const int dataPin,
 
             for (int i = 0; i<resultLen; i++) pio_sm_put_blocking(pio, 0, result[i]);
         }
-        else if (buffer[0] == 0x41) { // Origin (NOT 0x81)
+        else if (joybusByte == 0x41) { // Origin (NOT 0x81)
             gpio_put(25, 1);
             uint8_t originResponse[10] = { 0x00, 0x80, ORG, ORG, ORG, ORG, 0, 0, 0, 0 };
             // TODO The origin response sends centered values in this code excerpt. Consider whether that makes sense for your project (digital controllers -> yes)
@@ -152,7 +154,7 @@ void __time_critical_func(enterMode)(const int dataPin,
 
             for (int i = 0; i<resultLen; i++) pio_sm_put_blocking(pio, 0, result[i]);
         }
-        else if (buffer[0] == 0x40) { // Could check values past the first byte for reliability
+        else if (joybusByte == 0x40) { // Could check values past the first byte for reliability
             //The call to the state building function happens here, because on digital controllers, it's near instant, so it can be done between the poll and the response
             // It must be very fast (few us max) to be done between poll and response and still be compatible with adapters
             // Consider whether that makes sense for your project. If your state building is long, use a different control flow i.e precompute somehow and have func read it
@@ -160,16 +162,16 @@ void __time_critical_func(enterMode)(const int dataPin,
             GCReport dest_report;
 
 			//get the second byte; we do this interleaved with work that must be done
-            buffer[0] = pio_sm_get_blocking(pio, 0);
+            joybusByte = pio_sm_get_blocking(pio, 0);
 
-            convertGCReport(&gcReport, &dest_report, buffer[0]);
+            convertGCReport(&gcReport, &dest_report, joybusByte);
 
             uint32_t result[5];
             int resultLen;
             convertToPio((uint8_t*)(&dest_report), 8, result, resultLen);
 
 			//get the third byte; we do this interleaved with work that must be done
-            buffer[0] = pio_sm_get_blocking(pio, 0);
+            joybusByte = pio_sm_get_blocking(pio, 0);
 
 			//sleep_us(4);//add delay so we don't overwrite the stop bit
 			sleep_us(7);//add delay so we don't overwrite the stop bit
@@ -180,18 +182,11 @@ void __time_critical_func(enterMode)(const int dataPin,
 
             for (int i = 0; i<resultLen; i++) pio_sm_put_blocking(pio, 0, result[i]);
 
-			//Rumble
-            if(buffer[0] & 1) {
-                pwm_set_gpio_level(brakePin, 0);
-                pwm_set_gpio_level(rumblePin, abs(rumblePower));
-            } else if (rumblePower >= 0) {
-                pwm_set_gpio_level(rumblePin, 0);
-                pwm_set_gpio_level(brakePin, 255);
-            } else {
-                pwm_set_gpio_level(rumblePin, 0);
-                pwm_set_gpio_level(brakePin, 0);
-            }
+            bool rumbleBrake = joybusByte & 2;
+            bool rumble = (joybusByte & 1) && !rumbleBrake;
 
+            pwm_set_gpio_level(rumblePin, rumble ? std::abs(rumblePower) : 0);
+            pwm_set_gpio_level(brakePin, rumbleBrake ? 255 : 0);
         }
         else {
             pio_sm_set_enabled(pio, 0, false);


### PR DESCRIPTION
Currently the Phob 2 always brakes rumble, even when rumble is merely turned off (last bit of poll = rumble, 2nd last bit = rumble brake). This makes the rumble behavior match that of OEM GCCs