### PR TITLE
Add Trigger Mode 8 Locked Lightshield

### DIFF
--- a/PhobGCC/common/phobGCC.h
+++ b/PhobGCC/common/phobGCC.h
@@ -43,7 +43,7 @@ ControlConfig _controls{
 	.lConfig = 0,
 	.rConfig = 0,
 	.triggerConfigMin = 0,
-	.triggerConfigMax = 6,
+	.triggerConfigMax = 7,
 	.triggerDefault = 0,
 	.lTriggerOffset = 49,
 	.rTriggerOffset = 49,
@@ -1816,6 +1816,11 @@ void processButtons(Pins &pin, Buttons &btn, Buttons &hardware, ControlConfig &c
 		case 6: //Scales Analog Trigger Values
 			tempBtn.La = (uint8_t) readLa(pin, controls.lTrigInitial, triggerScaleL) * shutoffLa;
 			break;
+		case 7: //Locked Lightshield Value
+			if(tempBtn.La >= 43) {
+				tempBtn.La = (uint8_t) controls.lTriggerOffset;
+			}
+			break;
 		default:
 			tempBtn.La = (uint8_t) readLa(pin, controls.lTrigInitial, 1) * shutoffLa;
 	}
@@ -1855,6 +1860,11 @@ void processButtons(Pins &pin, Buttons &btn, Buttons &hardware, ControlConfig &c
 			break;
 		case 6: //Scales Analog Trigger Values
 			tempBtn.Ra = (uint8_t) readRa(pin, controls.rTrigInitial, triggerScaleR) * shutoffRa;
+			break;
+		case 7: //Locked Lightshield Value
+			if(tempBtn.Ra >= 43) {
+				tempBtn.Ra = (uint8_t) controls.rTriggerOffset;
+			}
 			break;
 		default:
 			tempBtn.Ra = (uint8_t) readRa(pin, controls.rTrigInitial, 1) * shutoffRa;


### PR DESCRIPTION
Adds an 8th trigger mode that uses overrides the entire lightshield range using crossing from 42 to 43 as the activation point and will always output the lightshield offset value, so that players can have specific lightshield amounts without sacrificing a digital trigger similar to box controllers which have two light shield buttons as well as two hard shield buttons, as well as allowing for low travel triggers to reach values that mode 4 would never get to and without having to use mode 7 which would introduce an incredible amount of jitter particularly in triggers with taller plugs. Discussed with CarVac some just a second ago but I'll go ahead and make it in case it's useful or wanted later on since I feel that mode 4+7 could still have the jitter issue for low travel triggers if nothing else.